### PR TITLE
Merged ADC-API with the fix

### DIFF
--- a/apis/peripherals/adc/src/lib.rs
+++ b/apis/peripherals/adc/src/lib.rs
@@ -75,13 +75,7 @@ impl<S: Syscalls> Adc<S> {
 
     /// Returns the reference voltage in millivolts (mV)
     pub fn get_reference_voltage_mv(channel: usize) -> Result<u32, ErrorCode> {
-        S::command(
-            DRIVER_NUM,
-            GET_VOLTAGE_REF,
-            (channel as usize).try_into().unwrap(),
-            0,
-        )
-        .to_result()
+        S::command(DRIVER_NUM, GET_VOLTAGE_REF, channel.try_into().unwrap(), 0).to_result()
     }
 }
 

--- a/apis/peripherals/adc/src/lib.rs
+++ b/apis/peripherals/adc/src/lib.rs
@@ -23,11 +23,17 @@ impl<S: Syscalls> Adc<S> {
             .and(Ok(()))
     }
 
-    // Initiate a sample reading
-    pub fn read_single_sample() -> Result<(), ErrorCode> {
-        S::command(DRIVER_NUM, SINGLE_SAMPLE, 0, 0).to_result()
+    // Returns the number of channels
+    pub fn get_number_of_channels() -> Result<usize, ErrorCode> {
+        S::command(DRIVER_NUM, EXISTS, 0, 0)
+            .to_result::<u32, ErrorCode>()
+            .and_then(|number_channels| number_channels.try_into().map_err(|_| ErrorCode::Fail))
     }
 
+    // Initiate a sample reading
+    pub fn read_single_sample(channel: usize) -> Result<(), ErrorCode> {
+        S::command(DRIVER_NUM, SINGLE_SAMPLE, channel as u32, 0).to_result()
+    }
     // Register a listener to be called when the ADC conversion is finished
     pub fn register_listener<'share, F: Fn(u16)>(
         listener: &'share ADCListener<F>,
@@ -43,14 +49,14 @@ impl<S: Syscalls> Adc<S> {
 
     /// Initiates a synchronous ADC conversion
     /// Returns the converted ADC value or an error
-    pub fn read_single_sample_sync() -> Result<u16, ErrorCode> {
+    pub fn read_single_sample_sync(channel: usize) -> Result<u16, ErrorCode> {
         let sample: Cell<Option<u16>> = Cell::new(None);
         let listener = ADCListener(|adc_val| {
             sample.set(Some(adc_val));
         });
         share::scope(|subscribe| {
             Self::register_listener(&listener, subscribe)?;
-            Self::read_single_sample()?;
+            Self::read_single_sample(channel)?;
             while sample.get().is_none() {
                 S::yield_wait();
             }
@@ -68,16 +74,22 @@ impl<S: Syscalls> Adc<S> {
     }
 
     /// Returns the reference voltage in millivolts (mV)
-    pub fn get_reference_voltage_mv() -> Result<u32, ErrorCode> {
-        S::command(DRIVER_NUM, GET_VOLTAGE_REF, 0, 0).to_result()
+    pub fn get_reference_voltage_mv(channel: usize) -> Result<u32, ErrorCode> {
+        S::command(
+            DRIVER_NUM,
+            GET_VOLTAGE_REF,
+            (channel as usize).try_into().unwrap(),
+            0,
+        )
+        .to_result()
     }
 }
 
 pub struct ADCListener<F: Fn(u16)>(pub F);
 
 impl<F: Fn(u16)> Upcall<OneId<DRIVER_NUM, 0>> for ADCListener<F> {
-    fn upcall(&self, adc_val: u32, _arg1: u32, _arg2: u32) {
-        self.0(adc_val as u16)
+    fn upcall(&self, _adc_mode: u32, _channel: u32, sample: u32) {
+        self.0(sample as u16)
     }
 }
 

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -20,12 +20,18 @@ fn main() {
         return;
     }
 
+    // Get the number of channels
+    let Ok(number_channels) = Adc::get_number_of_channels() else {
+        writeln!(Console::writer(), "can't get number of channels").unwrap();
+        return;
+    };
     loop {
-        match Adc::read_single_sample_sync() {
-            Ok(adc_val) => writeln!(Console::writer(), "Sample: {}\n", adc_val).unwrap(),
-            Err(_) => writeln!(Console::writer(), "error while reading sample",).unwrap(),
+        for i in 0..number_channels {
+            match Adc::read_single_sample_sync(i as usize) {
+                Ok(adc_val) => writeln!(Console::writer(), "Sample: {}\n", adc_val).unwrap(),
+                Err(_) => writeln!(Console::writer(), "error while reading sample",).unwrap(),
+            }
+            Alarm::sleep_for(Milliseconds(2000)).unwrap();
         }
-
-        Alarm::sleep_for(Milliseconds(2000)).unwrap();
     }
 }

--- a/unittest/src/fake/adc/mod.rs
+++ b/unittest/src/fake/adc/mod.rs
@@ -32,7 +32,7 @@ impl Adc {
     pub fn set_value(&self, channel: i32, sample: i32) {
         if self.busy.get() {
             self.share_ref
-                .schedule_upcall(0, (sample as u32, channel as u32, 0)) // Pass sample first for listener otherwise it will not see the correct value
+                .schedule_upcall(0, (sample as u32, channel as u32, 0)) // Pass sample first for listener otherwise it will not see the correct sample value
                 .expect("Unable to schedule upcall");
             self.busy.set(false);
         }

--- a/unittest/src/fake/adc/mod.rs
+++ b/unittest/src/fake/adc/mod.rs
@@ -32,7 +32,7 @@ impl Adc {
     pub fn set_value(&self, channel: i32, sample: i32) {
         if self.busy.get() {
             self.share_ref
-                .schedule_upcall(0, (sample as u32, channel as u32, 0)) // Pass sample first for listener otherwise it will not see the correct sample value
+                .schedule_upcall(0, (0, channel as u32, sample as u32))
                 .expect("Unable to schedule upcall");
             self.busy.set(false);
         }

--- a/unittest/src/fake/adc/mod.rs
+++ b/unittest/src/fake/adc/mod.rs
@@ -32,7 +32,7 @@ impl Adc {
     pub fn set_value(&self, channel: i32, sample: i32) {
         if self.busy.get() {
             self.share_ref
-                .schedule_upcall(0, (sample as u32, channel as u32, 0)) // Pass sample first for listener otherwise it will not see the correct sample value
+                .schedule_upcall(0, (sample as u32, channel as u32, 0)) // Pass sample first for listener otherwise it will not see the correct sample value.
                 .expect("Unable to schedule upcall");
             self.busy.set(false);
         }

--- a/unittest/src/fake/adc/mod.rs
+++ b/unittest/src/fake/adc/mod.rs
@@ -32,7 +32,7 @@ impl Adc {
     pub fn set_value(&self, channel: i32, sample: i32) {
         if self.busy.get() {
             self.share_ref
-                .schedule_upcall(0, (sample as u32, channel as u32, 0)) // Pass sample first for listener otherwise it will not see the correct sample value.
+                .schedule_upcall(0, (sample as u32, channel as u32, 0)) // Pass sample first for listener otherwise it will not see the correct sample value
                 .expect("Unable to schedule upcall");
             self.busy.set(false);
         }

--- a/unittest/src/fake/adc/mod.rs
+++ b/unittest/src/fake/adc/mod.rs
@@ -32,7 +32,7 @@ impl Adc {
     pub fn set_value(&self, channel: i32, sample: i32) {
         if self.busy.get() {
             self.share_ref
-                .schedule_upcall(0, (0, channel as u32, sample as u32))
+                .schedule_upcall(0, (sample as u32, channel as u32, 0)) // Pass sample first for listener otherwise it will not see the correct value
                 .expect("Unable to schedule upcall");
             self.busy.set(false);
         }

--- a/unittest/src/fake/adc/tests.rs
+++ b/unittest/src/fake/adc/tests.rs
@@ -16,11 +16,11 @@ fn command() {
         Some(ErrorCode::Busy)
     );
 
-    adc.set_value(100);
+    adc.set_value(0, 100);
     assert!(adc.command(SINGLE_SAMPLE, 0, 1).is_success());
-    adc.set_value(100);
+    adc.set_value(0, 100);
 
-    adc.set_value_sync(100);
+    adc.set_value_sync(0, 100);
     assert!(adc.command(SINGLE_SAMPLE, 0, 1).is_success());
     assert!(adc.command(SINGLE_SAMPLE, 0, 1).is_success());
 }
@@ -39,7 +39,7 @@ fn kernel_integration() {
         fake::Syscalls::command(DRIVER_NUM, SINGLE_SAMPLE, 0, 0).get_failure(),
         Some(ErrorCode::Busy)
     );
-    adc.set_value(100);
+    adc.set_value(0, 100);
     assert!(fake::Syscalls::command(DRIVER_NUM, SINGLE_SAMPLE, 0, 1).is_success());
 
     let listener = Cell::<Option<(u32,)>>::new(None);
@@ -49,18 +49,18 @@ fn kernel_integration() {
             Ok(())
         );
 
-        adc.set_value(100);
+        adc.set_value(0, 100);
         assert_eq!(fake::Syscalls::yield_no_wait(), YieldNoWaitReturn::Upcall);
         assert_eq!(listener.get(), Some((100,)));
 
-        adc.set_value(200);
+        adc.set_value(0, 200);
         assert_eq!(fake::Syscalls::yield_no_wait(), YieldNoWaitReturn::NoUpcall);
 
         assert!(fake::Syscalls::command(DRIVER_NUM, SINGLE_SAMPLE, 0, 1).is_success());
-        adc.set_value(200);
+        adc.set_value(0, 200);
         assert_eq!(fake::Syscalls::yield_no_wait(), YieldNoWaitReturn::Upcall);
 
-        adc.set_value_sync(200);
+        adc.set_value_sync(0, 200);
         assert!(fake::Syscalls::command(DRIVER_NUM, SINGLE_SAMPLE, 0, 1).is_success());
         assert_eq!(fake::Syscalls::yield_no_wait(), YieldNoWaitReturn::Upcall);
     });

--- a/unittest/src/fake/adc/tests.rs
+++ b/unittest/src/fake/adc/tests.rs
@@ -42,7 +42,7 @@ fn kernel_integration() {
     adc.set_value(0, 100);
     assert!(fake::Syscalls::command(DRIVER_NUM, SINGLE_SAMPLE, 0, 1).is_success());
 
-    let listener = Cell::<Option<(u32,)>>::new(None);
+    let listener = Cell::<Option<(u32, u32, u32)>>::new(None);
     share::scope(|subscribe| {
         assert_eq!(
             fake::Syscalls::subscribe::<_, _, DefaultConfig, DRIVER_NUM, 0>(subscribe, &listener),
@@ -51,7 +51,7 @@ fn kernel_integration() {
 
         adc.set_value(0, 100);
         assert_eq!(fake::Syscalls::yield_no_wait(), YieldNoWaitReturn::Upcall);
-        assert_eq!(listener.get(), Some((100,)));
+        assert_eq!(listener.get(), Some((0, 0, 100)));
 
         adc.set_value(0, 200);
         assert_eq!(fake::Syscalls::yield_no_wait(), YieldNoWaitReturn::NoUpcall);


### PR DESCRIPTION
- Merged ADC-API changes
- Modified the "read_single_sample" function to assign channel as u32 to avoid an unnecessary panic.
- Modified a test to properly asses the set value
The original listener test was asserting only the first argument of the .schedule_upcall which is not the sample.
Modifying the function to set sample as the first argument conflicts with the assessments in /peripherals/adc/src/test.rs
The test was modified to check for the third argument which was the where the sample should be checked for and now the test asserts the value correctly.


Signed-off-by: LithTheFox <denispavel94@gmail.com>